### PR TITLE
Adding index.name.override config

### DIFF
--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -88,6 +88,13 @@ Data Conversion
   * Valid Values: ``insert``, ``upsert``
   * Importance: low
 
+``index.name.override``
+  When defined, will override other index name logic and used as the index name to write documents to
+
+  * Type: string
+  * Default: ""
+  * Importance: low
+
 ``key.ignore``
   Whether to ignore the record key for the purpose of forming the OpenSearch document ID. When this is set to ``true``, document IDs will be generated according to the ``key.ignore.id.strategy`` strategy.
 


### PR DESCRIPTION
**New Feature:**
Adding new connector configuration index.name.override which allows for defining a static index name that documents will be written to.

**Current Behavior:**
Current logic for the index name is based off of the incoming kafka topic or data stream topic. 

**Problem this Solves:**
There currently isn't a way to change the topic with connector configuration. The only solution is to use the kafka connect transformer "org.apache.kafka.connect.transforms.RegexRouter" to remap the incoming topic(s).

The problem with this solution is when using the key.ignore.id.strategy with value of "topic.partition.offset", the topic in this key is always mapped to the static value defined by the RegexRouter, and will cause document collisions.

**Proposed Solution:**
Add new configuration  index.name.override which allows for defining a static index name that documents will be written to regardless of source topic(s).

**Existing Issues:**
https://github.com/aiven/opensearch-connector-for-apache-kafka/issues/89