### PR TITLE
Retry on inherited exceptions as well

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/RetryUtil.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/RetryUtil.java
@@ -118,7 +118,14 @@ public class RetryUtil {
                 LOGGER.trace("Try {} with attempt {}/{}", callName, attempts, maxAttempts);
                 return callable.call();
             } catch (final Exception e) {
-                if (attempts < maxAttempts && e.getClass().equals(repeatableException)) {
+                if (!repeatableException.isAssignableFrom(e.getClass())) {
+                    final var msg = String.format(
+                            "Non-repeatable exception trown by %s",
+                            callName
+                    );
+                    LOGGER.error(msg, e);
+                    throw new ConnectException(msg, e);
+                } else if (attempts < maxAttempts) {
                     final long sleepTimeMs = computeRandomRetryWaitTimeInMillis(retryAttempts, retryBackoffMs);
                     final var msg =
                             String.format(

--- a/src/test/java/io/aiven/kafka/connect/opensearch/RetryUtilTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/RetryUtilTest.java
@@ -17,9 +17,14 @@
 
 package io.aiven.kafka.connect.opensearch;
 
+import java.io.IOException;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RetryUtilTest {
@@ -47,6 +52,49 @@ public class RetryUtilTest {
         assertEquals(800L, RetryUtil.computeRetryWaitTimeInMillis(3, 100L));
         assertEquals(1600L, RetryUtil.computeRetryWaitTimeInMillis(4, 100L));
         assertEquals(3200L, RetryUtil.computeRetryWaitTimeInMillis(5, 100L));
+    }
+
+    @Test
+    public void callWithRetryRetriableError() {
+        final int[] attempt = new int[1];
+        final int maxRetries = 3;
+        final int res = RetryUtil.callWithRetry("test callWithRetryRetriableError", () -> {
+            if (attempt[0] < maxRetries) {
+                ++attempt[0];
+                throw new ArithmeticException();
+            }
+            return attempt[0];
+        }, maxRetries, 1L, RuntimeException.class);
+
+        assertEquals(maxRetries, res);
+    }
+
+    @Test
+    public void callWithRetryMaxRetries() {
+        final int[] attempt = new int[1];
+        final int maxRetries = 3;
+        assertThrows(
+            ConnectException.class,
+            () -> {
+                RetryUtil.callWithRetry("test callWithRetryMaxRetries", () -> {
+                    ++attempt[0];
+                    throw new ArithmeticException();
+                }, maxRetries, 1L, RuntimeException.class);
+            });
+
+        assertEquals(maxRetries + 1, attempt[0]);
+    }
+
+    @Test
+    public void callWithRetryNonRetriableError() {
+        final int maxRetries = 3;
+        assertThrows(
+            ConnectException.class,
+            () -> {
+                RetryUtil.callWithRetry("test callWithRetryNonRetriableError", () -> {
+                    throw new ArithmeticException();
+                }, maxRetries, 1L, IOException.class);
+            });
     }
 
     protected void assertComputeRetryInRange(final int retryAttempts, final long retryBackoffMs) {


### PR DESCRIPTION
The existing retry mechanism almost never triggered when the underlying function call throws an exception. In particular, it never retries to call a function if it fails with a connection error.

The mechanics was broken by `7249ad7 Add BulkProcessor` commit. So, there should not be any undesirable side-effects from retrying on all exceptions by default.

Issues: #179 