### PR TITLE
Upgrade kafka and other libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ curl http://localhost:8083/connector-plugins | jq .
   {
     "class": "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector",
     "type": "sink",
-    "version": "3.0.0"
+    "version": "3.3.0"
   },
   ...
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -131,12 +131,12 @@ publishing {
 }
 
 ext {
-    kafkaVersion = "2.8.1"
-    slf4jVersion = "1.7.36"
-    openSearchVersion = "2.13.0"
+    kafkaVersion = "3.5.0"
+    apacheCommonsLangVersion = "3.14.0"
+    slf4jVersion = "2.0.13"
+    openSearchVersion = "2.14.0"
 
-    testcontainersVersion = "1.19.7"
-    confluentPlatformVersion = "4.1.4"
+    testcontainersVersion = "1.19.8"
 }
 
 sourceSets {
@@ -173,6 +173,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation "com.google.code.gson:gson:2.10.1"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:$openSearchVersion"
+    implementation "org.apache.commons:commons-lang3:$apacheCommonsLangVersion"
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.10.2"
     testImplementation "org.mockito:mockito-core:5.11.0"

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ publishing {
 ext {
     kafkaVersion = "3.5.0"
     apacheCommonsLangVersion = "3.14.0"
-    slf4jVersion = "2.0.13"
+    slf4jVersion = "1.7.36"
     openSearchVersion = "2.14.0"
 
     testcontainersVersion = "1.19.8"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.aiven
-version=3.2.0-SNAPSHOT
+version=3.3.0-SNAPSHOT


### PR DESCRIPTION
This PR does the following.

- Upgrades kafka version from 2.8.0 to 3.5.0 which removes commons lang3 dependency. Had to add the dependency manually
- Add apache commons dependency
- Upgrade opensearch version and testContainer versions