### PR TITLE
Datastreams index template creation or check for existence

### DIFF
--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -215,7 +215,7 @@ Data Stream
   * Importance: medium
 
 ``data.streams.existing.index.template.name``
-  If data.streams.create.index.template is provided, data stream and index template will be created f it doesn't exist.
+  If data.streams.create.index.template is provided, data stream and index template will be created if it doesn't exist.
 
   * Type: string
   * Default: null

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -214,15 +214,8 @@ Data Stream
   * Valid Values: non-empty string
   * Importance: medium
 
-``data.streams.create.index.template``
-  If data streams is enabled and this is set to false, data stream and index template are not created, rather this value data.streams.existing.index.template.name is verified if it exists. If not datastream and template are created.
-
-  * Type: boolean
-  * Default: true
-  * Importance: medium
-
 ``data.streams.existing.index.template.name``
-  If data streams is enabled and data.streams.create.index.template is set to false, data stream and index template are not created, rather this value is verified if it exists. If not datastream and template are created.
+  If data.streams.create.index.template is provided, data stream and index template will be created f it doesn't exist.
 
   * Type: string
   * Default: null

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -214,6 +214,20 @@ Data Stream
   * Valid Values: non-empty string
   * Importance: medium
 
+``data.streams.create.index.template``
+  If data streams is enabled and this is set to false, data stream and index template are not created, rather this value data.streams.existing.index.template.name is verified if it exists. If not datastream and template are created.
+
+  * Type: boolean
+  * Default: true
+  * Importance: medium
+
+``data.streams.existing.index.template.name``
+  If data streams is enabled and data.streams.create.index.template is set to false, data stream and index template are not created, rather this value is verified if it exists. If not datastream and template are created.
+
+  * Type: string
+  * Default: null
+  * Importance: medium
+
 Authentication
 ^^^^^^^^^^^^^^
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
@@ -52,7 +52,7 @@ public abstract class AbstractIT {
         opensearchClient = new OpensearchClient(config);
     }
 
-    protected Map<String, String> getDefaultProperties() {
+    protected static Map<String, String> getDefaultProperties() {
         return Map.of(CONNECTION_URL_CONFIG, opensearchContainer.getHttpHostAddress(), CONNECTION_USERNAME_CONFIG,
                 "admin", CONNECTION_PASSWORD_CONFIG, "admin");
     }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -97,7 +97,7 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         }
     }
 
-    Map<String, String> connectorProperties(String topicName) {
+    static Map<String, String> connectorProperties(String topicName) {
         final var props = new HashMap<>(getDefaultProperties());
         props.put(CONNECTOR_CLASS_CONFIG, OpensearchSinkConnector.class.getName());
         props.put(TOPICS_CONFIG, topicName);
@@ -111,9 +111,9 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         return props;
     }
 
-    void writeRecords(final int numRecords, String topicName) {
+    void writeRecords(final int numRecords, String topicNameToWrite) {
         for (int i = 0; i < numRecords; i++) {
-            connect.kafka().produce(topicName, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
+            connect.kafka().produce(topicNameToWrite, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
         }
     }
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -97,7 +97,7 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         }
     }
 
-    Map<String, String> connectorProperties() {
+    Map<String, String> connectorProperties(String topicName) {
         final var props = new HashMap<>(getDefaultProperties());
         props.put(CONNECTOR_CLASS_CONFIG, OpensearchSinkConnector.class.getName());
         props.put(TOPICS_CONFIG, topicName);
@@ -111,7 +111,7 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         return props;
     }
 
-    void writeRecords(final int numRecords) {
+    void writeRecords(final int numRecords, String topicName) {
         for (int i = 0; i < numRecords; i++) {
             connect.kafka().produce(topicName, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
         }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
@@ -39,10 +39,10 @@ public class OpensearchSinkConnectorIT extends AbstractKafkaConnectIT {
 
     @Test
     public void testConnector() throws Exception {
-        connect.configureConnector(CONNECTOR_NAME, connectorProperties());
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties(TOPIC_NAME));
         waitForConnectorToStart(CONNECTOR_NAME, 1);
 
-        writeRecords(10);
+        writeRecords(10, TOPIC_NAME);
 
         waitForRecords(TOPIC_NAME, 10);
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkUpsertConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkUpsertConnectorIT.java
@@ -44,14 +44,14 @@ public class OpensearchSinkUpsertConnectorIT extends AbstractKafkaConnectIT {
 
     @Test
     public void testConnector() throws Exception {
-        final var props = connectorProperties();
+        final var props = connectorProperties(TOPIC_NAME);
         props.put(OpensearchSinkConnectorConfig.INDEX_WRITE_METHOD,
                 IndexWriteMethod.UPSERT.name().toLowerCase(Locale.ROOT));
         props.put(OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "false");
         connect.configureConnector(CONNECTOR_NAME, props);
         waitForConnectorToStart(CONNECTOR_NAME, 1);
 
-        writeRecords(3);
+        writeRecords(3, TOPIC_NAME);
 
         waitForRecords(TOPIC_NAME, 3);
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -170,8 +170,9 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
             + "If set to true the connector will write to data streams instead of regular indices. "
             + "Default is false.";
 
-    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If data streams is enabled and "
-            + "data.streams.create.index.template is set to false, this existing template has to be provided.";
+    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If "
+            + "data.streams.existing.index.template.name is provided, and if that index "
+            + "template does not exist, a template will be created with that name, else no template is created.";
 
     public static final String DATA_STREAM_PREFIX = "data.stream.prefix";
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -164,15 +164,11 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
             IndexWriteMethod.UPSERT.name().toLowerCase(Locale.ROOT));
 
     public static final String DATA_STREAM_ENABLED = "data.stream.enabled";
-    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE = "data.streams.create.index.template";
-    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME = "data.streams.existing.index.template.name";
+    public static final String DATA_STREAM_INDEX_TEMPLATE_NAME = "data.streams.existing.index.template.name";
 
     public static final String DATA_STREAM_ENABLED_DOC = "Enable use of data streams. "
             + "If set to true the connector will write to data streams instead of regular indices. "
             + "Default is false.";
-
-    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC = "If data streams is enabled and this is set to"
-            + " false, an existing template has to be provided. By default this is true.";
 
     public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If data streams is enabled and "
             + "data.streams.create.index.template is set to false, this existing template has to be provided.";
@@ -307,10 +303,7 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
                 .define(DATA_STREAM_TIMESTAMP_FIELD, Type.STRING, DATA_STREAM_TIMESTAMP_FIELD_DEFAULT,
                         new ConfigDef.NonEmptyString(), Importance.MEDIUM, DATA_STREAM_TIMESTAMP_FIELD_DOC,
                         DATA_STREAM_GROUP_NAME, ++order, Width.LONG, "Data stream timestamp field")
-                .define(DATA_STREAM_CREATE_INDEX_TEMPLATE, Type.BOOLEAN, true, Importance.MEDIUM,
-                        DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC, DATA_STREAM_GROUP_NAME, ++order, Width.LONG,
-                        "Data stream name")
-                .define(DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME, Type.STRING, null, Importance.MEDIUM,
+                .define(DATA_STREAM_INDEX_TEMPLATE_NAME, Type.STRING, null, Importance.MEDIUM,
                         DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC, DATA_STREAM_GROUP_NAME, ++order, Width.LONG,
                         "Data stream name");
     }
@@ -387,12 +380,8 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         return getBoolean(DATA_STREAM_ENABLED);
     }
 
-    public boolean dataStreamCreateIndexTemplate() {
-        return getBoolean(DATA_STREAM_CREATE_INDEX_TEMPLATE);
-    }
-
     public String dataStreamExistingIndexTemplateName() {
-        return getString(OpensearchSinkConnectorConfig.DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME);
+        return getString(OpensearchSinkConnectorConfig.DATA_STREAM_INDEX_TEMPLATE_NAME);
     }
 
     public Optional<String> dataStreamPrefix() {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -171,11 +171,11 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
             + "If set to true the connector will write to data streams instead of regular indices. "
             + "Default is false.";
 
-    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC = "If data streams is enabled and this is set to" +
-            " false, an existing template has to be provided. By default this is true.";
+    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC = "If data streams is enabled and this is set to"
+            + " false, an existing template has to be provided. By default this is true.";
 
-    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If data streams is enabled and " +
-            "data.streams.create.index.template is set to false, this existing template has to be provided.";
+    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If data streams is enabled and "
+            + "data.streams.create.index.template is set to false, this existing template has to be provided.";
 
     public static final String DATA_STREAM_PREFIX = "data.stream.prefix";
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -381,8 +381,8 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         return getBoolean(DATA_STREAM_ENABLED);
     }
 
-    public String dataStreamExistingIndexTemplateName() {
-        return getString(OpensearchSinkConnectorConfig.DATA_STREAM_INDEX_TEMPLATE_NAME);
+    public Optional<String> dataStreamExistingIndexTemplateName() {
+        return Optional.ofNullable(getString(OpensearchSinkConnectorConfig.DATA_STREAM_INDEX_TEMPLATE_NAME));
     }
 
     public Optional<String> dataStreamPrefix() {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -164,10 +164,18 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
             IndexWriteMethod.UPSERT.name().toLowerCase(Locale.ROOT));
 
     public static final String DATA_STREAM_ENABLED = "data.stream.enabled";
+    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE = "data.streams.create.index.template";
+    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME = "data.streams.existing.index.template.name";
 
     public static final String DATA_STREAM_ENABLED_DOC = "Enable use of data streams. "
             + "If set to true the connector will write to data streams instead of regular indices. "
             + "Default is false.";
+
+    public static final String DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC = "If data streams is enabled and this is set to" +
+            " false, an existing template has to be provided. By default this is true.";
+
+    public static final String DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC = "If data streams is enabled and " +
+            "data.streams.create.index.template is set to false, this existing template has to be provided.";
 
     public static final String DATA_STREAM_PREFIX = "data.stream.prefix";
 
@@ -298,7 +306,13 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
                         DATA_STREAM_NAME_DOC, DATA_STREAM_GROUP_NAME, ++order, Width.LONG, "Data stream name")
                 .define(DATA_STREAM_TIMESTAMP_FIELD, Type.STRING, DATA_STREAM_TIMESTAMP_FIELD_DEFAULT,
                         new ConfigDef.NonEmptyString(), Importance.MEDIUM, DATA_STREAM_TIMESTAMP_FIELD_DOC,
-                        DATA_STREAM_GROUP_NAME, ++order, Width.LONG, "Data stream timestamp field");
+                        DATA_STREAM_GROUP_NAME, ++order, Width.LONG, "Data stream timestamp field")
+                .define(DATA_STREAM_CREATE_INDEX_TEMPLATE, Type.BOOLEAN, true, Importance.MEDIUM,
+                        DATA_STREAM_CREATE_INDEX_TEMPLATE_DOC, DATA_STREAM_GROUP_NAME, ++order, Width.LONG,
+                        "Data stream name")
+                .define(DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME, Type.STRING, null, Importance.MEDIUM,
+                        DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME_DOC, DATA_STREAM_GROUP_NAME, ++order, Width.LONG,
+                        "Data stream name");
     }
 
     public static final ConfigDef CONFIG = baseConfigDef();
@@ -371,6 +385,14 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
 
     public boolean dataStreamEnabled() {
         return getBoolean(DATA_STREAM_ENABLED);
+    }
+
+    public boolean dataStreamCreateIndexTemplate() {
+        return getBoolean(DATA_STREAM_CREATE_INDEX_TEMPLATE);
+    }
+
+    public String dataStreamExistingIndexTemplateName() {
+        return getString(OpensearchSinkConnectorConfig.DATA_STREAM_EXISTING_INDEX_TEMPLATE_NAME);
     }
 
     public Optional<String> dataStreamPrefix() {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -142,7 +142,14 @@ public class OpensearchSinkTask extends SinkTask {
         if (!indexCache.contains(index)) {
             if (!client.indexOrDataStreamExists(index)) {
                 if (config.dataStreamEnabled()) {
-                    if (!config.dataStreamCreateIndexTemplate() && config.dataStreamExistingIndexTemplateName() != null
+                    // Create if data stream template if does not exist
+                    if (config.dataStreamExistingIndexTemplateName() != null
+                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")
+                            && !client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
+                        LOGGER.info("Create data stream and template {}", index);
+                        client.createIndexTemplateAndDataStream(config.dataStreamExistingIndexTemplateName(),
+                                config.dataStreamTimestampField());
+                    } else if (config.dataStreamExistingIndexTemplateName() != null
                             && !config.dataStreamExistingIndexTemplateName().trim().equals("")
                             && client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
                         LOGGER.info("Do not create data stream and template {}", index);

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -142,8 +142,13 @@ public class OpensearchSinkTask extends SinkTask {
         if (!indexCache.contains(index)) {
             if (!client.indexOrDataStreamExists(index)) {
                 if (config.dataStreamEnabled()) {
-                    LOGGER.info("Create data stream {}", index);
-                    client.createIndexTemplateAndDataStream(index, config.dataStreamTimestampField());
+                    if(!config.dataStreamCreateIndexTemplate() && config.dataStreamExistingIndexTemplateName() != null
+                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")){
+                        LOGGER.info("Do not create data stream {}", index);
+                    }else{
+                        LOGGER.info("Create data stream {}", index);
+                        client.createIndexTemplateAndDataStream(index, config.dataStreamTimestampField());
+                    }
                 } else {
                     LOGGER.info("Create index {}", index);
                     client.createIndex(index);

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -145,7 +145,7 @@ public class OpensearchSinkTask extends SinkTask {
                     if (!config.dataStreamCreateIndexTemplate() && config.dataStreamExistingIndexTemplateName() != null
                             && !config.dataStreamExistingIndexTemplateName().trim().equals("")
                             && client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
-                        LOGGER.info("Do not create data stream {}", index);
+                        LOGGER.info("Do not create data stream and template {}", index);
                     } else {
                         LOGGER.info("Create data stream {}", index);
                         client.createIndexTemplateAndDataStream(index, config.dataStreamTimestampField());

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -145,11 +145,12 @@ public class OpensearchSinkTask extends SinkTask {
                     if (config.dataStreamExistingIndexTemplateName().isPresent()) {
                         String userProvidedTemplate = config.dataStreamExistingIndexTemplateName().get();
                         if (!client.dataStreamIndexTemplateExists(userProvidedTemplate)) {
-                            LOGGER.info("Create data stream and template {}", index);
+                            LOGGER.info("Creating index template {} for data stream {}", userProvidedTemplate, index);
                             client.createIndexTemplateAndDataStream(userProvidedTemplate,
                                     config.dataStreamTimestampField());
                         } else {
-                            LOGGER.info("Do not create data stream and template {}", index);
+                            LOGGER.info("Using existing index template {} for data stream {}", userProvidedTemplate,
+                                    index);
                         }
                     } else {
                         LOGGER.info("Create data stream {}", index);

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -148,7 +148,7 @@ public class OpensearchSinkTask extends SinkTask {
                             LOGGER.info("Create data stream and template {}", index);
                             client.createIndexTemplateAndDataStream(userProvidedTemplate,
                                     config.dataStreamTimestampField());
-                        } else if (client.dataStreamIndexTemplateExists(userProvidedTemplate)) {
+                        } else {
                             LOGGER.info("Do not create data stream and template {}", index);
                         }
                     } else {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -142,17 +142,15 @@ public class OpensearchSinkTask extends SinkTask {
         if (!indexCache.contains(index)) {
             if (!client.indexOrDataStreamExists(index)) {
                 if (config.dataStreamEnabled()) {
-                    // Create if data stream template if does not exist
-                    if (config.dataStreamExistingIndexTemplateName() != null
-                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")
-                            && !client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
-                        LOGGER.info("Create data stream and template {}", index);
-                        client.createIndexTemplateAndDataStream(config.dataStreamExistingIndexTemplateName(),
-                                config.dataStreamTimestampField());
-                    } else if (config.dataStreamExistingIndexTemplateName() != null
-                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")
-                            && client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
-                        LOGGER.info("Do not create data stream and template {}", index);
+                    if (config.dataStreamExistingIndexTemplateName().isPresent()) {
+                        String userProvidedTemplate = config.dataStreamExistingIndexTemplateName().get();
+                        if (!client.dataStreamIndexTemplateExists(userProvidedTemplate)) {
+                            LOGGER.info("Create data stream and template {}", index);
+                            client.createIndexTemplateAndDataStream(userProvidedTemplate,
+                                    config.dataStreamTimestampField());
+                        } else if (client.dataStreamIndexTemplateExists(userProvidedTemplate)) {
+                            LOGGER.info("Do not create data stream and template {}", index);
+                        }
                     } else {
                         LOGGER.info("Create data stream {}", index);
                         client.createIndexTemplateAndDataStream(index, config.dataStreamTimestampField());

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -142,10 +142,11 @@ public class OpensearchSinkTask extends SinkTask {
         if (!indexCache.contains(index)) {
             if (!client.indexOrDataStreamExists(index)) {
                 if (config.dataStreamEnabled()) {
-                    if(!config.dataStreamCreateIndexTemplate() && config.dataStreamExistingIndexTemplateName() != null
-                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")){
+                    if (!config.dataStreamCreateIndexTemplate() && config.dataStreamExistingIndexTemplateName() != null
+                            && !config.dataStreamExistingIndexTemplateName().trim().equals("")
+                            && client.dataStreamIndexTemplateExists(config.dataStreamExistingIndexTemplateName())) {
                         LOGGER.info("Do not create data stream {}", index);
-                    }else{
+                    } else {
                         LOGGER.info("Create data stream {}", index);
                         client.createIndexTemplateAndDataStream(index, config.dataStreamTimestampField());
                     }


### PR DESCRIPTION
Resolves : #284 

Current behaviour : 
When data streams is enabled, a new index template is created by default

New behaviour : 
If data.streams.existing.index.template.name is provided, and if that index template does not exist, a template will be created with that name, else no template is created.

If data.streams.existing.index.template.name is not provided, a default template is always created
